### PR TITLE
Add executable 'doala'

### DIFF
--- a/exe/doala
+++ b/exe/doala
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# vim: set ft=ruby:
+
+require "doala"
+cmd = ARGV.first
+
+def available
+  Doala.methods(false)
+end
+
+def usage
+  $stderr.puts <<TXT
+Available commands are: #{available.join(", ")}
+TXT
+  exit 1
+end
+
+usage unless cmd
+
+unless available.include?(cmd.to_sym)
+  $stderr.puts "Not found '#{cmd}'" 
+  usage
+end
+
+puts Doala.send(cmd)


### PR DESCRIPTION
doala is very useful gem!

But I wanna to see the doala face, business_friend, etc more quickly.
This PR adds executable `doala` which enables the doala command such as below.

```shell-session
$ bundle exec doala
Available commands are: face, business_friend
$ bundle exec doala face
(⌒(´・△・`)⌒)
$ for a in $(seq 1 5); do bundle exec doala face; done
(⌒(´・△・`)⌒)
(⌒(´・△・`)⌒)
(⌒(´・△・`)⌒)
(⌒(´・△・`)⌒)
(⌒(´・△・`)⌒)
```

What's your feeling?